### PR TITLE
Default button only on topics list

### DIFF
--- a/settings.yml
+++ b/settings.yml
@@ -13,4 +13,4 @@ New_topic_button_title:
 Hide_default_button:
   default: true
   description:
-    en: Hide the default "New topic" button in topic lists?
+    en: Show only standard "New topic" button in topic lists


### PR DESCRIPTION
Make the `new topic` button appear in every page
![new](https://user-images.githubusercontent.com/32313429/59941947-055f4380-944e-11e9-8916-653d8bcc6d3a.png)

Except for the topic list where the old one already was
![old](https://user-images.githubusercontent.com/32313429/59941948-055f4380-944e-11e9-8c60-d081413ed998.png)
